### PR TITLE
Add option for not redering image text.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,66 +1,65 @@
 function Renderer (options) {
-    this.options = options || {};
-    this.whitespaceDelimiter = this.options.spaces ? ' ' : '\n';
-    this.showImageText = 'showImageText' in this.options ? this.options.showImageText : true;
-  }
-  
-  Renderer.prototype.code = function(code, lang, escaped) {
-    return this.whitespaceDelimiter + this.whitespaceDelimiter + code + this.whitespaceDelimiter + this.whitespaceDelimiter;
-  }
-  Renderer.prototype.blockquote = function(quote) {
-    return '\t' + quote + this.whitespaceDelimiter;
-  }
-  Renderer.prototype.html = function(html) {
-    return html;
-  }
-  Renderer.prototype.heading = function(text, level, raw) {
-    return text;
-  }
-  Renderer.prototype.hr = function() {
-    return this.whitespaceDelimiter + this.whitespaceDelimiter;
-  }
-  Renderer.prototype.list = function(body, ordered) {
-    return body;
-  }
-  Renderer.prototype.listitem = function(text) {
-    return '\t' + text + this.whitespaceDelimiter;
-  }
-  Renderer.prototype.paragraph = function(text) {
-    return this.whitespaceDelimiter + text + this.whitespaceDelimiter;
-  }
-  Renderer.prototype.table = function(header, body) {
-    return  this.whitespaceDelimiter + header + this.whitespaceDelimiter + body + this.whitespaceDelimiter;
-  }
-  Renderer.prototype.tablerow = function(content) {
-    return content + this.whitespaceDelimiter;
-  }
-  Renderer.prototype.tablecell = function(content, flags) {
-    return content + '\t';
-  }
-  Renderer.prototype.strong = function(text) {
-    return text;
-  }
-  Renderer.prototype.em = function(text) {
-    return text;
-  }
-  Renderer.prototype.codespan = function(text) {
-    return text;
-  }
-  Renderer.prototype.br = function() {
-    return this.whitespaceDelimiter + this.whitespaceDelimiter;
-  }
-  Renderer.prototype.del = function(text) {
-    return text;
-  }
-  Renderer.prototype.link = function(href, title, text) {
-    return text;
-  }
-  Renderer.prototype.image = function(href, title, text) {
-    return this.showImageText ? text : '';
-  }
-  Renderer.prototype.text = function(text) {
-    return text;
-  }
-  
-  module.exports = Renderer;
-  
+  this.options = options || {};
+  this.whitespaceDelimiter = this.options.spaces ? ' ' : '\n';
+  this.showImageText = 'showImageText' in this.options ? this.options.showImageText : true;
+}
+
+Renderer.prototype.code = function(code, lang, escaped) {
+  return this.whitespaceDelimiter + this.whitespaceDelimiter + code + this.whitespaceDelimiter + this.whitespaceDelimiter;
+}
+Renderer.prototype.blockquote = function(quote) {
+  return '\t' + quote + this.whitespaceDelimiter;
+}
+Renderer.prototype.html = function(html) {
+  return html;
+}
+Renderer.prototype.heading = function(text, level, raw) {
+  return text;
+}
+Renderer.prototype.hr = function() {
+  return this.whitespaceDelimiter + this.whitespaceDelimiter;
+}
+Renderer.prototype.list = function(body, ordered) {
+  return body;
+}
+Renderer.prototype.listitem = function(text) {
+  return '\t' + text + this.whitespaceDelimiter;
+}
+Renderer.prototype.paragraph = function(text) {
+  return this.whitespaceDelimiter + text + this.whitespaceDelimiter;
+}
+Renderer.prototype.table = function(header, body) {
+  return  this.whitespaceDelimiter + header + this.whitespaceDelimiter + body + this.whitespaceDelimiter;
+}
+Renderer.prototype.tablerow = function(content) {
+  return content + this.whitespaceDelimiter;
+}
+Renderer.prototype.tablecell = function(content, flags) {
+  return content + '\t';
+}
+Renderer.prototype.strong = function(text) {
+ return text;
+}
+Renderer.prototype.em = function(text) {
+ return text;
+}
+Renderer.prototype.codespan = function(text) {
+  return text;
+}
+Renderer.prototype.br = function() {
+  return this.whitespaceDelimiter + this.whitespaceDelimiter;
+}
+Renderer.prototype.del = function(text) {
+  return text;
+}
+Renderer.prototype.link = function(href, title, text) {
+  return text;
+}
+Renderer.prototype.image = function(href, title, text) {
+  return this.showImageText ? text : '';
+}
+Renderer.prototype.text = function(text) {
+  return text;
+}
+
+module.exports = Renderer;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 function Renderer (options) {
   this.options = options || {};
   this.whitespaceDelimiter = this.options.spaces ? ' ' : '\n';
-  this.showImageText = 'showImageText' in this.options ? this.options.showImageText : true;
+  this.showImageText = (typeof this.options !== 'undefined') ? this.options.showImageText : true;
 }
 
 Renderer.prototype.code = function(code, lang, escaped) {
@@ -38,10 +38,10 @@ Renderer.prototype.tablecell = function(content, flags) {
   return content + '\t';
 }
 Renderer.prototype.strong = function(text) {
- return text;
+  return text;
 }
 Renderer.prototype.em = function(text) {
- return text;
+  return text;
 }
 Renderer.prototype.codespan = function(text) {
   return text;

--- a/index.js
+++ b/index.js
@@ -1,64 +1,66 @@
 function Renderer (options) {
-  this.options = options || {};
-  this.whitespaceDelimiter = this.options.spaces ? ' ' : '\n';
-}
-
-Renderer.prototype.code = function(code, lang, escaped) {
-  return this.whitespaceDelimiter + this.whitespaceDelimiter + code + this.whitespaceDelimiter + this.whitespaceDelimiter;
-}
-Renderer.prototype.blockquote = function(quote) {
-  return '\t' + quote + this.whitespaceDelimiter;
-}
-Renderer.prototype.html = function(html) {
-  return html;
-}
-Renderer.prototype.heading = function(text, level, raw) {
-  return text;
-}
-Renderer.prototype.hr = function() {
-  return this.whitespaceDelimiter + this.whitespaceDelimiter;
-}
-Renderer.prototype.list = function(body, ordered) {
-  return body;
-}
-Renderer.prototype.listitem = function(text) {
-  return '\t' + text + this.whitespaceDelimiter;
-}
-Renderer.prototype.paragraph = function(text) {
-  return this.whitespaceDelimiter + text + this.whitespaceDelimiter;
-}
-Renderer.prototype.table = function(header, body) {
-  return  this.whitespaceDelimiter + header + this.whitespaceDelimiter + body + this.whitespaceDelimiter;
-}
-Renderer.prototype.tablerow = function(content) {
-  return content + this.whitespaceDelimiter;
-}
-Renderer.prototype.tablecell = function(content, flags) {
-  return content + '\t';
-}
-Renderer.prototype.strong = function(text) {
-  return text;
-}
-Renderer.prototype.em = function(text) {
-  return text;
-}
-Renderer.prototype.codespan = function(text) {
-  return text;
-}
-Renderer.prototype.br = function() {
-  return this.whitespaceDelimiter + this.whitespaceDelimiter;
-}
-Renderer.prototype.del = function(text) {
-  return text;
-}
-Renderer.prototype.link = function(href, title, text) {
-  return text;
-}
-Renderer.prototype.image = function(href, title, text) {
-  return text;
-}
-Renderer.prototype.text = function(text) {
-  return text;
-}
-
-module.exports = Renderer;
+    this.options = options || {};
+    this.whitespaceDelimiter = this.options.spaces ? ' ' : '\n';
+    this.showImageText = 'showImageText' in this.options ? this.options.showImageText : true;
+  }
+  
+  Renderer.prototype.code = function(code, lang, escaped) {
+    return this.whitespaceDelimiter + this.whitespaceDelimiter + code + this.whitespaceDelimiter + this.whitespaceDelimiter;
+  }
+  Renderer.prototype.blockquote = function(quote) {
+    return '\t' + quote + this.whitespaceDelimiter;
+  }
+  Renderer.prototype.html = function(html) {
+    return html;
+  }
+  Renderer.prototype.heading = function(text, level, raw) {
+    return text;
+  }
+  Renderer.prototype.hr = function() {
+    return this.whitespaceDelimiter + this.whitespaceDelimiter;
+  }
+  Renderer.prototype.list = function(body, ordered) {
+    return body;
+  }
+  Renderer.prototype.listitem = function(text) {
+    return '\t' + text + this.whitespaceDelimiter;
+  }
+  Renderer.prototype.paragraph = function(text) {
+    return this.whitespaceDelimiter + text + this.whitespaceDelimiter;
+  }
+  Renderer.prototype.table = function(header, body) {
+    return  this.whitespaceDelimiter + header + this.whitespaceDelimiter + body + this.whitespaceDelimiter;
+  }
+  Renderer.prototype.tablerow = function(content) {
+    return content + this.whitespaceDelimiter;
+  }
+  Renderer.prototype.tablecell = function(content, flags) {
+    return content + '\t';
+  }
+  Renderer.prototype.strong = function(text) {
+    return text;
+  }
+  Renderer.prototype.em = function(text) {
+    return text;
+  }
+  Renderer.prototype.codespan = function(text) {
+    return text;
+  }
+  Renderer.prototype.br = function() {
+    return this.whitespaceDelimiter + this.whitespaceDelimiter;
+  }
+  Renderer.prototype.del = function(text) {
+    return text;
+  }
+  Renderer.prototype.link = function(href, title, text) {
+    return text;
+  }
+  Renderer.prototype.image = function(href, title, text) {
+    return this.showImageText ? text : '';
+  }
+  Renderer.prototype.text = function(text) {
+    return text;
+  }
+  
+  module.exports = Renderer;
+  


### PR DESCRIPTION
Many times images are added by users with no image text and the default behavior from Markd is to pass the text 'iamge', either that or the original parser added the test 'image'. Even when image text is added it is incongruous with the surrounding text. This is especially true when generating summaries from the first n characters in block of markdown text.

This adds the ability to pass in the option { showImageText: true|false } to disable the display of the text associated with images in the passed in markdown.

The option defaults to true to maintain existing behavior when the showImageText image is not passed.
